### PR TITLE
Scan for schema files in libraries

### DIFF
--- a/src/main/com/intellij/lang/jsgraphql/ide/project/GraphQLPsiSearchHelper.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/GraphQLPsiSearchHelper.java
@@ -20,7 +20,7 @@ import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.GraphQLConfigManage
 import com.intellij.lang.jsgraphql.ide.project.indexing.GraphQLFragmentNameIndex;
 import com.intellij.lang.jsgraphql.ide.project.indexing.GraphQLIdentifierIndex;
 import com.intellij.lang.jsgraphql.ide.project.scopes.ConditionalGlobalSearchScope;
-import com.intellij.lang.jsgraphql.ide.project.scopes.SchemaInLibraryScope;
+import com.intellij.lang.jsgraphql.ide.project.scopes.MetaInfSchemaScope;
 import com.intellij.lang.jsgraphql.ide.references.GraphQLFindUsagesUtil;
 import com.intellij.lang.jsgraphql.psi.*;
 import com.intellij.lang.jsgraphql.schema.GraphQLExternalTypeDefinitionsProvider;
@@ -94,10 +94,7 @@ public class GraphQLPsiSearchHelper implements Disposable {
             .union(defaultProjectFileScope);
 
         final FileType[] searchScopeFileTypes = GraphQLFindUsagesUtil.getService().getIncludedFileTypes().toArray(FileType.EMPTY_ARRAY);
-        myGlobalScope = GlobalSearchScope
-            .getScopeRestrictedByFileTypes(GlobalSearchScope.projectScope(myProject), searchScopeFileTypes)
-            .union(myBuiltInSchemaScopes)
-            .union(new SchemaInLibraryScope(project));
+        myGlobalScope = createScope(null);
 
         project.getMessageBus().connect(this).subscribe(PsiManagerImpl.ANY_PSI_CHANGE_TOPIC, new AnyPsiChangeListener() {
             @Override
@@ -110,6 +107,23 @@ public class GraphQLPsiSearchHelper implements Disposable {
             public void afterPsiChanged(boolean isPhysical) {
             }
         });
+    }
+
+    @NotNull
+    private GlobalSearchScope createScope(@Nullable GlobalSearchScope filteredScope) {
+        GlobalSearchScope scope = GlobalSearchScope.projectScope(myProject);
+        if (filteredScope != null) {
+            scope = scope.intersectWith(filteredScope);
+        }
+
+        // these scopes are used unconditionally, both for global and config filtered scopes
+        scope = scope
+            .union(myBuiltInSchemaScopes)
+            .union(new MetaInfSchemaScope(myProject));
+
+        // filter all the resulting scopes by file types, we don't want some child scope to override this
+        FileType[] fileTypes = GraphQLFindUsagesUtil.getService().getIncludedFileTypes().toArray(FileType.EMPTY_ARRAY);
+        return GlobalSearchScope.getScopeRestrictedByFileTypes(scope, fileTypes);
     }
 
     /**
@@ -128,10 +142,9 @@ public class GraphQLPsiSearchHelper implements Disposable {
         PsiFile containingFile = element.getContainingFile();
         return myFileNameToSchemaScope.computeIfAbsent(GraphQLPsiUtil.getFileName(containingFile), fileName -> {
             final VirtualFile virtualFile = GraphQLPsiUtil.getOriginalVirtualFile(containingFile);
-            final NamedScope schemaScope = myConfigManager.getSchemaScope(virtualFile);
-            if (schemaScope != null) {
-                final GlobalSearchScope filterSearchScope = GlobalSearchScopesCore.filterScope(myProject, schemaScope);
-                return myGlobalScope.intersectWith(filterSearchScope.union(myBuiltInSchemaScopes));
+            final NamedScope configScope = myConfigManager.getSchemaScope(virtualFile);
+            if (configScope != null) {
+                return createScope(GlobalSearchScopesCore.filterScope(myProject, configScope));
             }
 
             // default is entire project limited by relevant file types

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/scopes/MetaInfSchemaScope.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/scopes/MetaInfSchemaScope.java
@@ -10,17 +10,21 @@ import com.intellij.psi.search.DelegatingGlobalSearchScope;
 import com.intellij.psi.search.GlobalSearchScope;
 import org.jetbrains.annotations.NotNull;
 
-public class SchemaInLibraryScope extends DelegatingGlobalSearchScope {
+public class MetaInfSchemaScope extends DelegatingGlobalSearchScope {
     private final ProjectFileIndex myIndex;
 
-    public SchemaInLibraryScope(@NotNull Project project) {
+    public MetaInfSchemaScope(@NotNull Project project) {
         super(GlobalSearchScope.getScopeRestrictedByFileTypes(GlobalSearchScope.allScope(project), GraphQLFileType.INSTANCE));
         myIndex = ProjectRootManager.getInstance(project).getFileIndex();
     }
 
     @Override
     public boolean contains(@NotNull VirtualFile file) {
-        return super.contains(file) && myIndex.isInLibrary(file) && myIndex.isInLibraryClasses(file) && file.getParent().getPath().endsWith("META-INF/schema");
+        return super.contains(file)
+            && myIndex.isInLibrary(file)
+            && myIndex.isInLibraryClasses(file)
+            && file.getParent() != null
+            && file.getParent().getPath().endsWith("META-INF/schema");
     }
 
     @Override

--- a/src/main/com/intellij/lang/jsgraphql/schema/GraphQLRegistryProvider.java
+++ b/src/main/com/intellij/lang/jsgraphql/schema/GraphQLRegistryProvider.java
@@ -16,7 +16,6 @@ import com.intellij.lang.jsgraphql.endpoint.ide.project.JSGraphQLEndpointNamedTy
 import com.intellij.lang.jsgraphql.ide.editor.GraphQLIntrospectionService;
 import com.intellij.lang.jsgraphql.ide.project.GraphQLPsiSearchHelper;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.GraphQLConfigManager;
-import com.intellij.lang.jsgraphql.ide.project.scopes.SchemaInLibraryScope;
 import com.intellij.lang.jsgraphql.psi.GraphQLFile;
 import com.intellij.lang.jsgraphql.psi.GraphQLPsiUtil;
 import com.intellij.lang.jsgraphql.types.GraphQLException;
@@ -69,7 +68,7 @@ public class GraphQLRegistryProvider implements Disposable {
 
     public GraphQLRegistryProvider(Project project) {
         this.project = project;
-        graphQLFilesScope = GlobalSearchScope.getScopeRestrictedByFileTypes(GlobalSearchScope.projectScope(project), GraphQLFileType.INSTANCE).union(new SchemaInLibraryScope(project));
+        graphQLFilesScope = GlobalSearchScope.getScopeRestrictedByFileTypes(GlobalSearchScope.allScope(project), GraphQLFileType.INSTANCE);
         jsonIntrospectionScope = GlobalSearchScope.getScopeRestrictedByFileTypes(GlobalSearchScope.projectScope(project), JsonFileType.INSTANCE);
         psiManager = PsiManager.getInstance(project);
         graphQLEndpointNamedTypeRegistry = JSGraphQLEndpointNamedTypeRegistry.getService(project);


### PR DESCRIPTION
At Netflix we have Java libraries with "common" GraphQL types. These types are shared by many GraphQL services. The libraries contain a schema in `META-INF/schema` and can optionally also contain code.

When writing a schema for a service, these types can be used just like types defined in the project. Scalar types are a common example. The problem is that the plugin doesn't recognize the types defined in the schema files provided by libraries, so it rightfully complains in the editor that the types are undefined. 

This PR changes the search scope for schema files to `allScope` instead of `projectScope`, which makes it include libraries as well. The following is an example of how that works.

![ScreenFlow](https://user-images.githubusercontent.com/109484/136300964-1074dc96-206c-4b37-86a1-e6e4aad24240.gif)

The schema in JAR file mechanism is supported by the [DGS framework](https://netflix.github.io/dgs/getting-started/), which is getting quite popular, so it's a mechanism that will likely benefit many users. I understand the plugin has been more JS-focused, but it's definitely just as useful for Java developers.
