### PR TITLE
Add @raw_response_type directive definition

### DIFF
--- a/resources/definitions/Relay.graphql
+++ b/resources/definitions/Relay.graphql
@@ -144,3 +144,9 @@ directive @prependNode(
     edgeTypeName: String!
 ) on FIELD
 
+"""
+A directive added to queries which tells Relay to generate types that cover
+the optimisticResponse parameter to commitMutation.
+"""
+directive @raw_response_type on QUERY | MUTATION | SUBSCRIPTION
+


### PR DESCRIPTION
To generate typings for the `optimisticResponse` fields on mutations, the relay compiler requires this new directive. 

See https://relay.dev/docs/glossary/#raw_response_type