### PR TITLE
Update to Federation 2

### DIFF
--- a/resources/definitions/Federation.graphql
+++ b/resources/definitions/Federation.graphql
@@ -1,5 +1,8 @@
 # https://www.apollographql.com/docs/federation/subgraph-spec/
 
+# a union of all types that use the @key directive
+union _Entity
+
 scalar _Any
 scalar FieldSet
 scalar link__Import

--- a/resources/definitions/Federation.graphql
+++ b/resources/definitions/Federation.graphql
@@ -38,4 +38,7 @@ directive @composeDirective(name: String!) repeatable on SCHEMA
 
 # This definition is required only for libraries that don't support
 # GraphQL's built-in `extend` keyword
-directive @extends on OBJECT | INTERFACE
+#
+# `repeatable` is technically not part of the spec, but is added here so that multiple `type Query @extends { ... }`
+# definitions from different DGS schemas would pass validation
+directive @extends repeatable on OBJECT | INTERFACE

--- a/resources/definitions/Federation.graphql
+++ b/resources/definitions/Federation.graphql
@@ -1,24 +1,41 @@
-# https://www.apollographql.com/docs/federation/federation-spec/#federation-schema-specification
-scalar _Any
-scalar _FieldSet
+# https://www.apollographql.com/docs/federation/subgraph-spec/
 
-# a union of all types that use the @key directive
-union _Entity
+scalar _Any
+scalar FieldSet
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
 
 type _Service {
-    sdl: String
+  sdl: String!
 }
 
 extend type Query {
-    _entities(representations: [_Any!]!): [_Entity]!
-    _service: _Service!
+  _entities(representations: [_Any!]!): [_Entity]!
+  _service: _Service!
 }
 
-directive @external on FIELD_DEFINITION
-directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
-directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
-directive @key(fields: _FieldSet!) repeatable on OBJECT | INTERFACE
+directive @external on FIELD_DEFINITION | OBJECT
+directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @link(url: String!, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+directive @shareable repeatable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION
+directive @composeDirective(name: String!) repeatable on SCHEMA
 
-# `repeatable` is technically not part of the spec, but is added here so that multiple `type Query @extends { ... }`
-# definitions from different DGS schemas would pass validation
-directive @extends repeatable on OBJECT | INTERFACE
+# This definition is required only for libraries that don't support
+# GraphQL's built-in `extend` keyword
+directive @extends on OBJECT | INTERFACE


### PR DESCRIPTION
Resolves https://github.com/JetBrains/js-graphql-intellij-plugin/issues/627

Federation 2 is backward compatible with the directives of Federation 1. Directives either were added to new locations or marked as repeatable. Looking at this file it looks like it would be breaking to go from `_FieldSet` to `FieldSet` but this should be purely internal change 