### PR TITLE
Add configContributor EP

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -40,6 +40,8 @@
                     interface="com.intellij.lang.jsgraphql.ide.findUsages.GraphQLFindUsagesFileTypeContributor"/>
     <extensionPoint name="errorFilter" dynamic="true"
                     interface="com.intellij.lang.jsgraphql.ide.validation.GraphQLErrorFilter"/>
+    <extensionPoint name="configContributor" dynamic="true"
+                    interface="com.intellij.lang.jsgraphql.ide.project.graphqlconfig.provider.GraphQLConfigContributor"/>
   </extensionPoints>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/GraphQLConfigManager.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/GraphQLConfigManager.java
@@ -27,6 +27,7 @@ import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfig
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfigEndpoint;
 import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLResolvedConfigData;
 import com.intellij.lang.jsgraphql.ide.findUsages.GraphQLFindUsagesUtil;
+import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.provider.GraphQLConfigContributor;
 import com.intellij.lang.jsgraphql.psi.GraphQLFile;
 import com.intellij.lang.jsgraphql.psi.GraphQLPsiUtil;
 import com.intellij.lang.jsgraphql.schema.GraphQLSchemaKeys;
@@ -659,6 +660,13 @@ public class GraphQLConfigManager implements Disposable {
                     createParseErrorNotification(yamlFile, e);
                 }
             });
+        }
+
+        // Plugin contributed config files
+        final GraphQLConfigContributor[] configContributors = GraphQLConfigContributor.EP_NAME.getExtensions();
+        for (GraphQLConfigContributor configContributor : configContributors) {
+            Map<VirtualFile, GraphQLConfigData> configDataByPath = configContributor.getGraphQLConfigurationsByPath(myProject);
+            configDataByPath.forEach(newConfigPathToConfigurations::putIfAbsent);
         }
 
         // apply defaults to projects as spec'ed in https://github.com/kamilkisiela/graphql-config/tree/legacyspecification.md#default-configuration-properties

--- a/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/provider/GraphQLConfigContributor.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/project/graphqlconfig/provider/GraphQLConfigContributor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022-present, Benoit Lubek
+ * All rights reserved.
+ * <p>
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package com.intellij.lang.jsgraphql.ide.project.graphqlconfig.provider;
+
+import com.intellij.lang.jsgraphql.ide.project.graphqlconfig.model.GraphQLConfigData;
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+/**
+ * Plugins can implement this EP to provide GraphQL configs for a project.
+ */
+public interface GraphQLConfigContributor {
+
+    ExtensionPointName<GraphQLConfigContributor> EP_NAME = ExtensionPointName.create("com.intellij.lang.jsgraphql.configContributor");
+
+    /**
+     * Provide GraphQL configs by path for a given project.
+     *
+     * @return key: a VirtualFile that must point to a directory, value: the GraphQLConfigData for that directory.
+     */
+    @NotNull
+    Map<@NotNull VirtualFile, @NotNull GraphQLConfigData> getGraphQLConfigurationsByPath(@NotNull Project project);
+}


### PR DESCRIPTION
Hi!

I am working on an IntelliJ plugin for [Apollo Kotlin](https://github.com/apollographql/apollo-kotlin). In its current form, the plugin declares a dependency on the GraphQL plugin for its edition and language features.

Now we’d like to improve the integration between the 2 plugins, by allowing the GraphQL plugin to have awareness of the location of GraphQL files that are managed by Apollo Kotlin.

### Context

Within an Apollo Kotlin project, GraphQL schema and operation files must be located in specific folders (there’s a default value, which can be customized). 
It is also possible to declare several independent [“services”](https://www.apollographql.com/docs/kotlin/advanced/plugin-configuration#using-multiple-graphql-apis), which have their own schema. 
Lastly, multiple modules are supported, in which case operation files can be scattered in different locations.

### Current situation

For simple Apollo Kotlin projects (only 1 service), the GraphQL plugin already works well and a `.graphqlconfig` file isn’t even needed.

For Apollo Kotlin projects with several services, the GraphQL plugin isn’t aware of which schema an operation relates to. For instance, if service A’s schema defines a `products` field, and B’s schema defines a `person` field, when editing a query inside A’s folder, the user will have completion suggesting both fields, even though `person` doesn’t apply. 
Similarly if both schemas define a type with the same name, it will be underlined as an error, as the plugin thinks it is a re-declaration in the same schema.

This can be resolved by having a `.graphqlconfig` file in the project, similar to this:

```json
{
  "projects": {
    "serviceA": {
      "includes": ["graphqlSchema/src/main/graphql/serviceA/*"]
    },
    "serviceB": {
      "includes": ["graphqlSchema/src/main/graphql/serviceB/*"]
    }
  }
}
```

But of course it is a bit of work to create and maintain the file, if the project’s layout change it could be out of sync, and generally, it would be nice if it “just worked out of the box”.

### Suggested change

Have a way for plugins to inform the GraphQL plugin of the projects and file includes/excludes.

To that effect, in addition to being able to configure the plugin via the `.graphqlconfig` file as it exists today, an Extension Point can be added to the plugin, so other plugins can provide their configuration.

### This PR

I’m opening this as a draft, as a means to start a discussion and see if I’m on the right track! 

A `configContributor` Extension Point is added, as well as the corresponding `GraphQLConfigContributor` interface:

```java
public interface GraphQLConfigContributor {
    /**
     * Provide GraphQL configs by path for a given project.
     *
     * @return key: a VirtualFile that must point to a directory, value: the GraphQLConfigData for that directory.
     */
    Map<VirtualFile, GraphQLConfigData> getGraphQLConfigurationsByPath(Project project);
}
```

Then `GraphQLConfigManager.doBuildConfigurationModel()` is updated to call `getGraphQLConfigurationsByPath` and add the returned value to the map being computed.

Note that this is done *after* reading the `.graphqlconfig` files, giving them precedence - this gives users the ability to override what’s configured automatically by a plugin, if needed.

#### Handling configuration changes

At the moment, I am not 100% sure of the conditions that re-trigger `doBuildConfigurationModel()` to be called, but we probably need a mechanism for a plugin to notify that its configuration has changed, and that therefore `getGraphQLConfigurationsByPath` must be called again. 

Not sure yet if this could be handled with another method in `GraphQLConfigContributor` (something like `setConfigChangeListener` maybe), or via another mechanism (maybe the [messaging](https://plugins.jetbrains.com/docs/intellij/messaging-infrastructure.html) API?).

--- 

Anyway, please don’t hesitate to tell me if this makes sense / if I’m missing anything :). Thanks!