### PR TITLE
Add GraphQLBuiltInRedefinitionErrorFilter

### DIFF
--- a/src/main/com/intellij/lang/jsgraphql/ide/validation/GraphQLBuiltInRedefinitionErrorFilter.kt
+++ b/src/main/com/intellij/lang/jsgraphql/ide/validation/GraphQLBuiltInRedefinitionErrorFilter.kt
@@ -1,0 +1,47 @@
+package com.intellij.lang.jsgraphql.ide.validation
+
+import com.intellij.lang.jsgraphql.types.GraphQLError
+import com.intellij.lang.jsgraphql.types.language.DirectiveDefinition
+import com.intellij.lang.jsgraphql.types.language.EnumTypeDefinition
+import com.intellij.lang.jsgraphql.types.language.ObjectTypeDefinition
+import com.intellij.lang.jsgraphql.types.language.ScalarTypeDefinition
+import com.intellij.lang.jsgraphql.types.schema.idl.errors.DirectiveRedefinitionError
+import com.intellij.lang.jsgraphql.types.schema.idl.errors.TypeRedefinitionError
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+
+/**
+ * Suppress redefinition errors for built-in GraphQL types/directives, as it is valid to have them defined in an application's schema.
+ */
+class GraphQLBuiltInRedefinitionErrorFilter : GraphQLErrorFilter {
+    private val builtInScalars = listOf("Int", "Float", "String", "Boolean", "ID")
+    private val builtInDirectives = listOf("skip", "include", "deprecated", "defer", "specifiedBy")
+
+    override fun isGraphQLErrorSuppressed(project: Project, error: GraphQLError, element: PsiElement?): Boolean {
+        return when (error) {
+            is TypeRedefinitionError -> {
+                when (val node = error.node) {
+                    is ScalarTypeDefinition -> {
+                        node.name in builtInScalars
+                    }
+
+                    is ObjectTypeDefinition -> {
+                        node.name.startsWith("__")
+                    }
+
+                    is EnumTypeDefinition -> {
+                        node.name.startsWith("__")
+                    }
+
+                    else -> false
+                }
+            }
+
+            is DirectiveRedefinitionError -> {
+                (error.node as DirectiveDefinition).name in builtInDirectives
+            }
+
+            else -> false
+        }
+    }
+}

--- a/src/test/com/intellij/lang/jsgraphql/validation/GraphQLSchemaValidationTest.java
+++ b/src/test/com/intellij/lang/jsgraphql/validation/GraphQLSchemaValidationTest.java
@@ -31,6 +31,10 @@ public class GraphQLSchemaValidationTest extends GraphQLTestCaseBase {
         doHighlightingTest();
     }
 
+    public void testBuiltInRedefinitionErrors() {
+        doHighlightingTest();
+    }
+
     public void testImplementingErrors() {
         doHighlightingTest();
     }

--- a/test-resources/testData/graphql/validation/schema/BuiltInRedefinitionErrors.graphql
+++ b/test-resources/testData/graphql/validation/schema/BuiltInRedefinitionErrors.graphql
@@ -1,0 +1,23 @@
+scalar String
+scalar Int
+scalar Boolean
+scalar Boolean
+scalar Boolean
+
+type __Schema {
+    description: String
+}
+
+enum __TypeKind {
+    SCALAR
+}
+
+directive @defer (label: String, if: Boolean! = true) on FRAGMENT_SPREAD|INLINE_FRAGMENT
+
+directive @include ("Included when true." if: Boolean!) on FIELD|FRAGMENT_SPREAD|INLINE_FRAGMENT
+
+directive @skip ("Skipped when true." if: Boolean!) on FIELD|FRAGMENT_SPREAD|INLINE_FRAGMENT
+
+directive @deprecated ("Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https:\/\/commonmark.org\/)." reason: String = "No longer supported") on FIELD_DEFINITION|ARGUMENT_DEFINITION|INPUT_FIELD_DEFINITION|ENUM_VALUE
+
+directive @specifiedBy ("The URL that specifies the behavior of this scalar." url: String!) on SCALAR


### PR DESCRIPTION
This is a fix for #665.

As discussed in that issue, this is the simple fix using an error filter, while a better fix would be to prioritize user-defined types always. But at least this fixes the immediate issue in a simple way.