### PR TITLE
Fix deprecated input fields not showing up

### DIFF
--- a/src/main/com/intellij/lang/jsgraphql/ide/introspection/GraphQLIntrospectionQuery.java
+++ b/src/main/com/intellij/lang/jsgraphql/ide/introspection/GraphQLIntrospectionQuery.java
@@ -30,7 +30,7 @@ public interface GraphQLIntrospectionQuery {
                                "    fields(includeDeprecated: true) {\n" +
                                "      name\n" +
                                "      description\n" +
-                               "      args {\n" +
+                               "      args(includeDeprecated: true) {\n" +
                                "        ...InputValue\n" +
                                "      }\n" +
                                "      type {\n" +
@@ -39,8 +39,7 @@ public interface GraphQLIntrospectionQuery {
                                "      isDeprecated\n" +
                                "      deprecationReason\n" +
                                "    }\n" +
-                               "    inputFields {\n" +
-                               // (includeDeprecated: true)
+                               "    inputFields(includeDeprecated: true) {\n" +
                                "      ...InputValue\n" +
                                "    }\n" +
                                "    interfaces {\n" +
@@ -62,8 +61,8 @@ public interface GraphQLIntrospectionQuery {
                                "    description\n" +
                                "    type { ...TypeRef }\n" +
                                "    defaultValue\n" +
-                               // "    isDeprecated\n" +
-                               // "    deprecationReason\n" +
+                               "    isDeprecated\n" +
+                               "    deprecationReason\n" +
                                "  }\n" +
                                "\n" +
                                //


### PR DESCRIPTION
It seems the default introspection query has `(includeDeprecated: true)` commented out, why was this the case in the first place? It seems the commit that added deprecated fields, included these as comments in the same commit: https://github.com/JetBrains/js-graphql-intellij-plugin/commit/b81990f213472dad552a4d64d53d8bba3fa0b54f

We're having trouble fetching Shopify's GraphQL schema without it, which has a lot of input fields marked as deprecated:
https://shopify.dev/docs/api/admin-graphql/2024-07/input-objects/ProductVariantInput#field-productvariantinput-fulfillmentserviceid