### PR TITLE
Inject GQL on gql(`query`) syntax

### DIFF
--- a/src/main/com/intellij/lang/jsgraphql/javascript/injection/GraphQLJavaScriptLanguageInjectionUtil.java
+++ b/src/main/com/intellij/lang/jsgraphql/javascript/injection/GraphQLJavaScriptLanguageInjectionUtil.java
@@ -43,6 +43,7 @@ public final class GraphQLJavaScriptLanguageInjectionUtil {
   public static final String APOLLO_GQL_TEMPLATE_TAG = "Apollo.gql";
 
   private static final ElementPattern<JSExpression> GRAPHQL_CALL_ARG_PATTERN = JSPatterns.jsArgument(GRAPHQL_TEMPLATE_TAG, 0);
+  private static final ElementPattern<JSExpression> GQL_CALL_ARG_PATTERN = JSPatterns.jsArgument(GQL_TEMPLATE_TAG, 0);
 
   public static final Set<String> SUPPORTED_TAG_NAMES = Sets.newHashSet(
     RELAY_QL_TEMPLATE_TAG,
@@ -112,7 +113,7 @@ public final class GraphQLJavaScriptLanguageInjectionUtil {
   private static boolean isInjectedInCallArgument(@NotNull JSStringTemplateExpression template) {
     PsiElement parent = template.getParent();
     PsiElement expr = parent instanceof ES6TaggedTemplateExpression ? parent : template;
-    return GRAPHQL_CALL_ARG_PATTERN.accepts(expr);
+    return GRAPHQL_CALL_ARG_PATTERN.accepts(expr) || GQL_CALL_ARG_PATTERN.accepts(expr);
   }
 
   /**


### PR DESCRIPTION
In one of our projects we use gql(`query`) to define our GraphQL queries. This PR introduces support for this syntax in addtion to graphql(`query`).