### PR TITLE
[graphql] support mjs, cts, and mts config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,10 @@ The plugin supports multiple configuration file formats. Here is a list of all t
 - graphql.config.json
 - graphql.config.js
 - graphql.config.cjs
+- graphql.config.mjs
 - graphql.config.ts
+- graphql.config.cts
+- graphql.config.mts
 - graphql.config.yaml
 - graphql.config.yml
 - .graphqlrc (YAML and JSON)
@@ -307,7 +310,11 @@ The plugin supports multiple configuration file formats. Here is a list of all t
 - .graphqlrc.yaml
 - .graphqlrc.yml
 - .graphqlrc.js
+- .graphqlrc.cjs
+- .graphqlrc.mjs
 - .graphqlrc.ts
+- .graphqlrc.cts
+- .graphqlrc.mts
 
 ### Yaml
 

--- a/src/main/com/intellij/lang/jsgraphql/ide/config/GraphQLConfigConstants.kt
+++ b/src/main/com/intellij/lang/jsgraphql/ide/config/GraphQLConfigConstants.kt
@@ -20,8 +20,11 @@ val LEGACY_CONFIG_NAMES: Set<String> = linkedSetOf(
 )
 
 const val GRAPHQL_CONFIG_TS = "graphql.config.ts"
+const val GRAPHQL_CONFIG_CTS = "graphql.config.cts"
+const val GRAPHQL_CONFIG_MTS = "graphql.config.mts"
 const val GRAPHQL_CONFIG_JS = "graphql.config.js"
 const val GRAPHQL_CONFIG_CJS = "graphql.config.cjs"
+const val GRAPHQL_CONFIG_MJS = "graphql.config.mjs"
 
 const val GRAPHQL_CONFIG_JSON = "graphql.config.json"
 const val GRAPHQL_CONFIG_YAML = "graphql.config.yaml"
@@ -29,8 +32,11 @@ const val GRAPHQL_CONFIG_YML = "graphql.config.yml"
 
 const val GRAPHQL_RC = ".graphqlrc"
 const val GRAPHQL_RC_TS = ".graphqlrc.ts"
+const val GRAPHQL_RC_CTS = ".graphqlrc.cts"
+const val GRAPHQL_RC_MTS = ".graphqlrc.mts"
 const val GRAPHQL_RC_JS = ".graphqlrc.js"
 const val GRAPHQL_RC_CJS = ".graphqlrc.cjs"
+const val GRAPHQL_RC_MJS = ".graphqlrc.mjs"
 
 const val GRAPHQL_RC_JSON = ".graphqlrc.json"
 const val GRAPHQL_RC_YAML = ".graphqlrc.yaml"
@@ -39,16 +45,22 @@ const val GRAPHQL_RC_YML = ".graphqlrc.yml"
 @JvmField
 val MODERN_CONFIG_NAMES: Set<String> = linkedSetOf(
   GRAPHQL_CONFIG_TS,
+  GRAPHQL_CONFIG_CTS,
+  GRAPHQL_CONFIG_MTS,
   GRAPHQL_CONFIG_JS,
   GRAPHQL_CONFIG_CJS,
+  GRAPHQL_CONFIG_MJS,
   GRAPHQL_CONFIG_JSON,
   GRAPHQL_CONFIG_YAML,
   GRAPHQL_CONFIG_YML,
   //    "graphql.config.toml",
   GRAPHQL_RC,
   GRAPHQL_RC_TS,
+  GRAPHQL_RC_CTS,
+  GRAPHQL_RC_MTS,
   GRAPHQL_RC_JS,
   GRAPHQL_RC_CJS,
+  GRAPHQL_RC_MJS,
   GRAPHQL_RC_JSON,
   GRAPHQL_RC_YAML,
   GRAPHQL_RC_YML,

--- a/src/main/com/intellij/lang/jsgraphql/ide/config/loader/GraphQLConfigLoader.kt
+++ b/src/main/com/intellij/lang/jsgraphql/ide/config/loader/GraphQLConfigLoader.kt
@@ -127,7 +127,7 @@ class GraphQLConfigLoader(private val project: Project) {
     return when (file.extension) {
       "json" -> readJson(file)
       "yaml", "yml" -> readYml(file)
-      "js", "cjs", "ts" -> readJs(file)
+      "js", "cjs", "mjs", "ts", "cts", "mts" -> readJs(file)
       else -> when (file.name) {
         GRAPHQLCONFIG -> readJson(file)
         GRAPHQL_RC -> readContentDependent(file)

--- a/src/main/com/intellij/lang/jsgraphql/javascript/config/GraphQLJavaScriptConfigLoader.kt
+++ b/src/main/com/intellij/lang/jsgraphql/javascript/config/GraphQLJavaScriptConfigLoader.kt
@@ -30,7 +30,7 @@ private const val TIMEOUT = 15000
 
 private val LOG = logger<GraphQLJavaScriptConfigLoader>()
 
-private val EXTENSIONS = setOf("js", "ts", "cjs")
+private val EXTENSIONS = setOf("js", "ts", "cjs", "mjs", "cts", "mts")
 
 class GraphQLJavaScriptConfigLoader : GraphQLConfigCustomLoader {
 


### PR DESCRIPTION
Parity with [GraphQL-Config - Config Search Places](https://the-guild.dev/graphql/config/docs/user/usage#config-search-places).

Fixes #740.