### PR TITLE
Add support for descriptions on executable definitions

### DIFF
--- a/src/grammars/GraphQLParser.bnf
+++ b/src/grammars/GraphQLParser.bnf
@@ -204,15 +204,15 @@ typedOperationDefinition ::= typedOperationDefinitionHeader selectionSet {
   mixin="com.intellij.lang.jsgraphql.psi.impl.GraphQLTypedOperationDefinitionMixin"
 }
 
-private typedOperationDefinitionHeader ::= operationType identifier? variableDefinitions? directives? {
-  pin=1
+private typedOperationDefinitionHeader ::= description? operationType identifier? variableDefinitions? directives? {
+  pin=2
   recoverWhile=rootTokens_recover
 }
 
 variableDefinitions ::= '(' variableDefinition+ ')' {pin=1 methods=[variableDefinitions="variableDefinition"]}
 
-variableDefinition ::= variable <<colon type>> defaultValue? directives? {
-  pin=1
+variableDefinition ::= description? variable <<colon type>> defaultValue? directives? {
+  pin=2
   recoverWhile=variableDefinition_recover
   methods=[directives="directive"]
   implements="com.intellij.lang.jsgraphql.psi.GraphQLDirectivesAware"
@@ -263,8 +263,8 @@ fragmentDefinition ::= fragmentDefinitionHeader selectionSet {
   mixin="com.intellij.lang.jsgraphql.psi.impl.GraphQLFragmentDefinitionMixin"
 }
 
-private fragmentDefinitionHeader ::= 'fragment' fragmentName typeCondition directives? {
-  pin=1
+private fragmentDefinitionHeader ::= description? 'fragment' fragmentName typeCondition directives? {
+  pin=2
   recoverWhile=rootTokens_recover
 }
 


### PR DESCRIPTION
This has recently been added to the spec (see https://github.com/graphql/graphql-spec/pull/1170).

Note: the `generateLexer` task fails with `In plugin 'org.jetbrains.grammarkit.GrammarKitPlugin$Inject' type 'org.jetbrains.grammarkit.tasks.GenerateLexerTask' property 'sourceFile' doesn't have a configured value.`,  - not sure how to re generate the code on this project.